### PR TITLE
Undefined name: 'f' --> 'path'

### DIFF
--- a/data/data_utils.py
+++ b/data/data_utils.py
@@ -88,7 +88,7 @@ def import_cpn_poses(path):
     
     
 def import_sh_poses(path):
-    with h5py.File(f) as hf:
+    with h5py.File(path) as hf:
         positions = hf['poses'].value
     return positions.astype('float32')
     


### PR DESCRIPTION
__f__ is an _undefined name_ in this context but __path__ is an unused function parameter on the line above.

[flake8](http://flake8.pycqa.org) testing of https://github.com/facebookresearch/VideoPose3D on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./data/data_utils.py:91:20: F821 undefined name 'f'
    with h5py.File(f) as hf:
                   ^
1     F821 undefined name 'f'
1
```